### PR TITLE
Perfective edits to my post, as well as SEO

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,10 @@ assets:
 
 # Authors
 authors:
+  # Note: jekyll-seo-tag expects these keys to be your Twitter handle.
+  # If you want your posts to be associated with your Twitter handle,
+  # make sure your short name here to match your @: 
+  # See: https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/advanced-usage.md#author-information
   aidan:
     name: Aidan
     display_name: Aidan

--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ authors:
     web: https://aidanpine.ca
     twitter: https://twitter.com/aidanpine
     description: "Lead developer of Mother Tongues."
-  eddie:
+  _eddieantonio:
     name: Eddie
     display_name: Eddie
     gravatar: 7183e460abfb84d668e408c32631abd4
@@ -64,7 +64,13 @@ jekyll-archives:
 # Pagination 
 paginate: 6
 paginate_path: /page:num/
-    
+
+# SEO
+twitter:
+  # the "site's" username
+  username: AidanPine
+  card: summary_large_image
+
 # Other
 markdown: kramdown
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
 
 <title>{{ page.title }} | {{site.name}}</title>
 
-{% seo %}
+{% seo title=false %}
 
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     

--- a/_posts/2020-08-07-why-a-new-cree-syllabics-converter.md
+++ b/_posts/2020-08-07-why-a-new-cree-syllabics-converter.md
@@ -10,7 +10,8 @@ featured: false
 hidden: false
 ---
 
-The Western Cree languages—**Plains Cree**, **Woods Cree**, and **Swampy Cree**—are written using two systems: one with letters borrowed from the English, in a system known as the **standard Roman orthography** (**SRO**), and **ᓀᐦᐃᔭᐏ ᒐᐦᑭᐯᐦᐃᑲᓇ** (Cree syllabics). SRO is relatively easy to type on a modern computer, but syllabics are more difficult, because of the lack of a well-established syllabics input layout. It's easier to just use a **converter** which, given Cree text in SRO, produces Cree text in syllabics. In this post, I describe my criticisms of the converters that existed prior to July 2018, and introduce [syllabics.app][]—a syllabics converter that I developed in reaction to the former converters.
+The Western Cree languages—**Plains Cree**, **Woods Cree**, and **Swampy Cree**—are written using two systems: one with letters borrowed from the
+English alphabet, in a system known as the **standard Roman orthography** (**SRO**), and **ᓀᐦᐃᔭᐏ ᒐᐦᑭᐯᐦᐃᑲᓇ** (Cree syllabics). SRO is relatively easy to type on a modern computer, but syllabics are more difficult, because of the lack of a well-established syllabics input layout. It's easier to just use a **converter** which, given Cree text in SRO, produces Cree text in syllabics. In this post, I describe my criticisms of the converters that existed prior to July 2018, and introduce [syllabics.app][]—a syllabics converter that I developed in reaction to the former converters.
 
 [syllabics.app]: https://syllabics.app/
 

--- a/_posts/2020-08-07-why-a-new-cree-syllabics-converter.md
+++ b/_posts/2020-08-07-why-a-new-cree-syllabics-converter.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  Why I made yet another Cree syllabics converter
-author: eddie
+author: _eddieantonio
 categories: [ Blog ]
 tags: [ basic ]
 image: assets/images/why-cree-syllabics--header.png

--- a/_posts/2020-08-07-why-a-new-cree-syllabics-converter.md
+++ b/_posts/2020-08-07-why-a-new-cree-syllabics-converter.md
@@ -5,7 +5,7 @@ author: _eddieantonio
 categories: [ Blog ]
 tags: [ basic ]
 image: assets/images/why-cree-syllabics--header.png
-description: "How do existing converters fall short, and how have I decided to fix it?"
+description: "How existing converters fall short, and how I have addressed these shortcomings."
 featured: false
 hidden: false
 ---


### PR DESCRIPTION
Just a few edits, plus I wrestled with Jekyll's SEO plugin to stop producing an extra `<title>` tag; and now it outputs Twitter tags, so that our posts show up with nice, big images when posted on  Twitter!

@roedoejet I divided these changes into small commits. If any of the changes are disagreeable, we can revert _just_ the offending changes!